### PR TITLE
## Title
feat: Enhance commit and PR commands, add changelog generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9, '3.10', '3.11']
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e ".[dev]"
+    
+    - name: Run tests
+      run: |
+        make test
+    
+    - name: Run linting
+      run: |
+        make lint
+    
+    - name: Upload coverage
+      uses: codecov/codecov-action@v3
+      with:
+        file: ./coverage.xml
+        fail_ci_if_error: true
+
+  deploy:
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build twine
+    
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      run: |
+        python -m build
+        twine upload dist/* 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,94 +6,13 @@
 ### Chores
 
 - add CHANGELOG.md
+- add CHANGELOG.md
 
 ### Other
 
+- enhance changelog generation
+- simplify add and commit commands
 - enhance feature descriptions and add changelog guide
 - add version parsing and comparison
 - add --create-tag option to changelog command
-
-## v1.0.0-beta.1
-
-*Released on *
-
-### Features
-
-- add new feature (placeholder message)
-
-### Documentation
-
-- update README with new changelog command
-- update author and contact information in README, setup.py, and OpenAI API calls
-
-### Refactor
-
-- update AI model to GPT for commit message generation
-
-### Chores
-
-- add MIT license file
-
-### Other
-
-- enhance add command and update CLI
-- make labels and checklist opt-in
-- improve PR command options
-- add PR enhancement features
-- enhance PR creation with labels and checklist
-- add prompts for commit messages and PR descriptions
-- add prompts and refactor commit message generation
-- implement PR creation using GitHub CLI
-- extract LLM API call to separate function
-- simplify generate_pr_description function
-- simplify get_commit_history function
-- simplify PR command, remove GitHub CLI integration
-- pass group flag to commit_command based on user input
-- update get_commit_history to compare against remote
-- add smart commit grouping option
-- add license and project URLs
-- update analyze_changes to group related file changes
-- add MIT license badge
-- Add stage_files and unstage_files functions for selective staging
-- Update commit command description
-- Merge pull request #13 from PayasPandey11/new_1
-- simplify get_commit_history to use main..HEAD
-- Merge pull request #12 from PayasPandey11/new_1
-- update installation instructions, add Makefile commands, and troubleshooting section
-- Merge pull request #11 from PayasPandey11/new_1
-- Simplify catch-all command handling
-- Merge pull request #10 from PayasPandey11/new_1
-- add Makefile, update README, and update dependencies
-- Merge pull request #9 from PayasPandey11/new_1
-- switch to OpenRouter API and Claude model
-- Merge pull request #8 from PayasPandey11/new_1
-- Improve error handling in 'add' command
-- Merge pull request #7 from PayasPandey11/new_1
-- Updated comments in llm.py to focus on code changes, not functionality or features. Updated generation of PR description to emphasize functionality and features, not code changes.
-- Merge pull request #6 from PayasPandey11/new_1
-- Improve gitwise CLI command handling
-- Merge pull request #5 from PayasPandey11/new_1
-- Enhance gitwise CLI for direct git command usage
-- Merge pull request #4 from PayasPandey11/new_1
-- improve commit message guidelines
-- Merge pull request #3 from PayasPandey11/new_1
-- add command categories for gitwise
-- Merge pull request #2 from PayasPandey11/new_1
-- Ensure proper exit code when no git command is provided
-- prompt user to create pull request if not on main branch
-- Add setup.py for project configuration
-- Merge pull request #1 from PayasPandey11/dev
-- Improve error messages for no commits found
-- improve commit message to include branch details
-- Add validation checks before creating a pull request
-- add command for creating pull requests
-- improve commit message generation logic
-- implement user authentication system
-- Add push command to handle pushing changes to remote repository.
-- Refactor git push logic to allow pushing to different branches
-- Add option to push changes after committing.
-- Refactor CLI to support running as a script from gitwise/ directory.
-- Add AI-powered git assistant for generating smart commit messages, PR descriptions, and changelogs using open-source LLMs.
-- Generate commit message using BitNet LLM
-- Initial commit
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,126 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+rpayaspandey@gmail.com. All complaints will be reviewed and investigated
+promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+
+[homepage]: https://www.contributor-covenant.org
+[Mozilla CoC]: https://github.com/mozilla/diversity 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# Contributing to GitWise
+
+Thank you for your interest in contributing to GitWise! This document provides guidelines and instructions for contributing.
+
+## Development Setup
+
+1. Fork the repository
+2. Clone your fork:
+   ```bash
+   git clone https://github.com/your-username/gitwise.git
+   cd gitwise
+   ```
+3. Create a virtual environment:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+   ```
+4. Install development dependencies:
+   ```bash
+   make install-dev
+   ```
+
+## Development Workflow
+
+1. Create a new branch for your feature/fix:
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```
+2. Make your changes
+3. Run tests:
+   ```bash
+   make test
+   ```
+4. Run linting:
+   ```bash
+   make lint
+   ```
+5. Commit your changes using conventional commits:
+   ```bash
+   gitwise commit "feat: add new feature"
+   ```
+6. Push your branch and create a pull request
+
+## Code Style
+
+- Follow PEP 8 style guide
+- Use type hints for all functions
+- Write docstrings for all functions
+- Keep functions small and focused
+- Write tests for new features
+
+## Testing
+
+- Write unit tests for new features
+- Ensure all tests pass before submitting PR
+- Maintain or improve test coverage
+- Run tests with: `make test`
+
+## Documentation
+
+- Update README.md if needed
+- Add docstrings to new functions
+- Update CHANGELOG.md for significant changes
+- Add examples for new features
+
+## Pull Request Process
+
+1. Update the README.md with details of changes if needed
+2. Update the CHANGELOG.md with your changes
+3. Ensure all tests pass
+4. Ensure linting passes
+5. Request review from maintainers
+
+## Development Commands
+
+- `make install`: Install package
+- `make install-dev`: Install development dependencies
+- `make test`: Run tests
+- `make lint`: Run linting
+- `make format`: Format code
+- `make clean`: Clean build files
+
+## Questions?
+
+Feel free to open an issue for any questions or concerns. 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,21 @@
+include LICENSE
+include README.md
+include CHANGELOG.md
+include CONTRIBUTING.md
+include CODE_OF_CONDUCT.md
+include requirements.txt
+include Makefile
+
+recursive-include tests *
+recursive-exclude * __pycache__
+recursive-exclude * *.py[cod]
+recursive-exclude * *.so
+recursive-exclude * .git
+recursive-exclude * .github
+recursive-exclude * .venv
+recursive-exclude * .pytest_cache
+recursive-exclude * .coverage
+recursive-exclude * htmlcov
+recursive-exclude * dist
+recursive-exclude * build
+recursive-exclude * *.egg-info 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,245 @@
+# GitWise API Documentation
+
+GitWise is an AI-powered git assistant that helps you write better commit messages, manage changelogs, and create pull requests. This document provides a comprehensive overview of the GitWise API.
+
+## Core Features
+
+### Commit Management
+
+#### `commit_command(message: str = None, group: bool = False)`
+
+Creates a commit with either a provided message or an AI-generated message based on staged changes.
+
+**Parameters:**
+- `message` (str, optional): Commit message to use
+- `group` (bool): Whether to group changes and generate a smart commit message
+
+**Example:**
+```python
+# Commit with provided message
+commit_command(message="feat: add new feature")
+
+# Commit with AI-generated message
+commit_command(group=True)
+```
+
+#### `group_commits(diffs: List[Diff])`
+
+Groups changes into categories based on their type and content.
+
+**Parameters:**
+- `diffs` (List[Diff]): List of git diff objects
+
+**Returns:**
+- Dictionary with categories as keys and lists of changes as values
+
+**Example:**
+```python
+groups = group_commits(diffs)
+# Returns: {"Features": [...], "Bug Fixes": [...], ...}
+```
+
+#### `generate_commit_message(groups: Dict[str, List[str]])`
+
+Generates a conventional commit message from grouped changes.
+
+**Parameters:**
+- `groups` (Dict[str, List[str]]): Dictionary of change groups
+
+**Returns:**
+- String containing the formatted commit message
+
+**Example:**
+```python
+message = generate_commit_message({
+    "Features": ["new feature"],
+    "Bug Fixes": ["fix bug"]
+})
+```
+
+### Pull Request Management
+
+#### `pr_command(title: str = None, base: str = None, draft: bool = False)`
+
+Creates a pull request with either a provided title or an AI-generated title based on commits.
+
+**Parameters:**
+- `title` (str, optional): PR title to use
+- `base` (str, optional): Base branch for the PR
+- `draft` (bool): Whether to create a draft PR
+
+**Example:**
+```python
+# Create PR with provided title
+pr_command(title="Add new feature")
+
+# Create PR with AI-generated title
+pr_command(draft=True)
+```
+
+#### `generate_pr_title()`
+
+Generates a PR title based on commit messages since the base branch.
+
+**Returns:**
+- String containing the PR title
+
+**Example:**
+```python
+title = generate_pr_title()
+```
+
+#### `generate_pr_description()`
+
+Generates a PR description with categorized changes and breaking changes.
+
+**Returns:**
+- String containing the formatted PR description
+
+**Example:**
+```python
+description = generate_pr_description()
+```
+
+### Changelog Management
+
+#### `changelog_command(version: str = None, auto_update: bool = False, setup_hook: bool = False)`
+
+Generates or updates the changelog.
+
+**Parameters:**
+- `version` (str, optional): Version to generate changelog for
+- `auto_update` (bool): Whether to update the unreleased section
+- `setup_hook` (bool): Whether to set up the git commit hook
+
+**Example:**
+```python
+# Generate changelog for all versions
+changelog_command()
+
+# Generate changelog for specific version
+changelog_command(version="v1.0.0")
+
+# Update unreleased section
+changelog_command(auto_update=True)
+```
+
+#### `get_version_tags()`
+
+Retrieves all version tags from the repository.
+
+**Returns:**
+- List of version tags sorted by version number
+
+**Example:**
+```python
+tags = get_version_tags()
+```
+
+#### `update_changelog(version: str, commits: List[Commit])`
+
+Updates the CHANGELOG.md file with a new version entry.
+
+**Parameters:**
+- `version` (str): Version number
+- `commits` (List[Commit]): List of commit objects
+
+**Example:**
+```python
+update_changelog("v1.0.0", commits)
+```
+
+## Utility Functions
+
+### Git Operations
+
+#### `get_current_branch()`
+
+Gets the name of the current branch.
+
+**Returns:**
+- String containing the branch name
+
+**Example:**
+```python
+branch = get_current_branch()
+```
+
+#### `get_base_branch()`
+
+Gets the default base branch for the repository.
+
+**Returns:**
+- String containing the base branch name
+
+**Example:**
+```python
+base = get_base_branch()
+```
+
+### Validation
+
+#### `validate_commit_message(message: str)`
+
+Validates a commit message against conventional commit format.
+
+**Parameters:**
+- `message` (str): Commit message to validate
+
+**Returns:**
+- Boolean indicating if the message is valid
+
+**Example:**
+```python
+is_valid = validate_commit_message("feat: add new feature")
+```
+
+#### `validate_branch_name(branch: str)`
+
+Validates a branch name against naming conventions.
+
+**Parameters:**
+- `branch` (str): Branch name to validate
+
+**Returns:**
+- Boolean indicating if the name is valid
+
+**Example:**
+```python
+is_valid = validate_branch_name("feature/new-feature")
+```
+
+## Best Practices
+
+1. **Commit Messages**
+   - Use conventional commit format
+   - Include scope when applicable
+   - Add breaking change indicators when needed
+
+2. **Branch Names**
+   - Use feature/, fix/, docs/ prefixes
+   - Use kebab-case for multi-word names
+   - Avoid protected branch names
+
+3. **Pull Requests**
+   - Create from feature branches
+   - Include clear descriptions
+   - Use draft PRs for work in progress
+
+4. **Changelog**
+   - Keep [Unreleased] section up to date
+   - Use semantic versioning
+   - Include breaking changes
+
+## Error Handling
+
+All functions raise appropriate exceptions when:
+- Git operations fail
+- Validation fails
+- Required parameters are missing
+- No changes are found
+- Invalid version formats are used
+
+## Contributing
+
+Contributions to the API are welcome! Please see [CONTRIBUTING.md](../CONTRIBUTING.md) for guidelines. 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,241 @@
+# Changelog Feature Documentation
+
+The changelog feature in GitWise provides automated changelog generation and management. It helps maintain a clear record of changes in your project by automatically categorizing commits and generating well-formatted changelog entries.
+
+## Features
+
+- Automatic version detection and changelog generation
+- Smart categorization of changes based on commit messages
+- Support for conventional commit messages
+- Automatic inclusion of release dates
+- Clean markdown formatting
+- Pre-commit hook for automatic updates
+- Unreleased changes tracking
+
+## API Reference
+
+### `get_version_tags()`
+
+Retrieves all version tags from the repository.
+
+**Returns:**
+- List of version tags sorted by version number
+
+**Example:**
+```python
+tags = get_version_tags()
+# Returns: [v1.0.0, v1.1.0, v2.0.0]
+```
+
+### `get_commits_between_tags(start_tag, end_tag)`
+
+Fetches all commits between two version tags.
+
+**Parameters:**
+- `start_tag` (str): Starting version tag
+- `end_tag` (str): Ending version tag
+
+**Returns:**
+- List of commit objects
+
+**Example:**
+```python
+commits = get_commits_between_tags("v1.0.0", "v1.1.0")
+```
+
+### `categorize_changes(commits)`
+
+Categorizes commits by type based on conventional commit messages.
+
+**Parameters:**
+- `commits` (list): List of commit objects
+
+**Returns:**
+- Dictionary with categories as keys and lists of commits as values
+
+**Categories:**
+- Features
+- Bug Fixes
+- Documentation
+- Performance
+- Security
+- Breaking Changes
+- Other
+
+**Example:**
+```python
+categories = categorize_changes(commits)
+# Returns: {"Features": [...], "Bug Fixes": [...], ...}
+```
+
+### `generate_changelog_entry(version, commits)`
+
+Generates a markdown formatted changelog entry for a specific version.
+
+**Parameters:**
+- `version` (str): Version number
+- `commits` (list): List of commit objects
+
+**Returns:**
+- String containing the formatted changelog entry
+
+**Example:**
+```python
+entry = generate_changelog_entry("v1.0.0", commits)
+```
+
+### `get_repository_info()`
+
+Gets information about the current repository.
+
+**Returns:**
+- Dictionary containing repository URL and name
+
+**Example:**
+```python
+info = get_repository_info()
+# Returns: {"url": "https://github.com/user/repo.git", "name": "repo"}
+```
+
+### `generate_release_notes(commits, repo_info)`
+
+Generates user-friendly release notes from commits.
+
+**Parameters:**
+- `commits` (list): List of commit objects
+- `repo_info` (dict): Repository information
+
+**Returns:**
+- String containing formatted release notes
+
+**Example:**
+```python
+notes = generate_release_notes(commits, repo_info)
+```
+
+### `update_changelog(version, commits)`
+
+Updates the CHANGELOG.md file with a new version entry.
+
+**Parameters:**
+- `version` (str): Version number
+- `commits` (list): List of commit objects
+
+**Example:**
+```python
+update_changelog("v1.0.0", commits)
+```
+
+### `get_unreleased_changes()`
+
+Gets all commits since the last version tag.
+
+**Returns:**
+- List of commit objects
+
+**Example:**
+```python
+changes = get_unreleased_changes()
+```
+
+### `update_unreleased_changelog(commits)`
+
+Updates the [Unreleased] section of the changelog.
+
+**Parameters:**
+- `commits` (list): List of commit objects
+
+**Example:**
+```python
+update_unreleased_changelog(commits)
+```
+
+### `commit_hook()`
+
+Git pre-commit hook that updates the changelog.
+
+**Example:**
+```python
+commit_hook()
+```
+
+### `setup_commit_hook()`
+
+Sets up the git pre-commit hook for automatic changelog updates.
+
+**Example:**
+```python
+setup_commit_hook()
+```
+
+## Command Line Interface
+
+### `gitwise changelog [version]`
+
+Generates a changelog for the repository.
+
+**Options:**
+- `version`: Optional version number to generate changelog for
+- `--auto-update`: Update the unreleased section
+- `--setup-hook`: Set up the git commit hook
+
+**Examples:**
+```bash
+# Generate changelog for all versions
+gitwise changelog
+
+# Generate changelog for specific version
+gitwise changelog v1.0.0
+
+# Update unreleased section
+gitwise changelog --auto-update
+
+# Set up commit hook
+gitwise changelog --setup-hook
+```
+
+## Best Practices
+
+1. **Use Conventional Commits**
+   - Start commit messages with type: `feat:`, `fix:`, `docs:`, etc.
+   - This ensures proper categorization in the changelog
+
+2. **Version Tags**
+   - Use semantic versioning: `v1.0.0`, `v1.1.0`, etc.
+   - Tag releases after merging to main branch
+
+3. **Changelog Maintenance**
+   - Keep the [Unreleased] section up to date
+   - Review changelog entries before releases
+   - Use the pre-commit hook for automatic updates
+
+4. **Release Process**
+   ```bash
+   # 1. Update unreleased section
+   gitwise changelog --auto-update
+   
+   # 2. Create version tag
+   git tag v1.0.0
+   
+   # 3. Generate release notes
+   gitwise changelog v1.0.0
+   ```
+
+## Troubleshooting
+
+1. **Missing Version Tags**
+   - Ensure tags are properly created with `git tag`
+   - Check tag format matches semantic versioning
+
+2. **Commit Hook Issues**
+   - Verify hook installation with `gitwise changelog --setup-hook`
+   - Check hook permissions in `.git/hooks/pre-commit`
+
+3. **Changelog Format**
+   - Ensure CHANGELOG.md exists
+   - Maintain proper markdown formatting
+   - Keep [Unreleased] section at the top
+
+## Contributing
+
+Contributions to the changelog feature are welcome! Please see [CONTRIBUTING.md](../CONTRIBUTING.md) for guidelines. 

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -1,0 +1,158 @@
+import os
+import pytest
+from datetime import datetime
+from unittest.mock import patch, MagicMock
+from gitwise.features.changelog import (
+    get_version_tags,
+    get_commits_between_tags,
+    categorize_changes,
+    generate_changelog_entry,
+    changelog_command,
+    get_repository_info,
+    generate_release_notes,
+    update_changelog,
+    get_unreleased_changes,
+    update_unreleased_changelog,
+    commit_hook,
+    setup_commit_hook
+)
+
+@pytest.fixture
+def mock_repo():
+    with patch('gitwise.features.changelog.Repo') as mock:
+        repo = MagicMock()
+        mock.return_value = repo
+        yield repo
+
+@pytest.fixture
+def mock_commit():
+    commit = MagicMock()
+    commit.message = "feat: add new feature"
+    commit.hexsha = "abc123"
+    commit.committed_datetime = datetime.now()
+    return commit
+
+def test_get_version_tags(mock_repo):
+    mock_repo.tags = [
+        MagicMock(name="v1.0.0"),
+        MagicMock(name="v1.1.0"),
+        MagicMock(name="v2.0.0")
+    ]
+    tags = get_version_tags()
+    assert len(tags) == 3
+    assert tags[0].name == "v1.0.0"
+
+def test_get_commits_between_tags(mock_repo, mock_commit):
+    mock_repo.iter_commits.return_value = [mock_commit]
+    commits = get_commits_between_tags("v1.0.0", "v1.1.0")
+    assert len(commits) == 1
+    assert commits[0].message == "feat: add new feature"
+
+def test_categorize_changes(mock_commit):
+    commits = [mock_commit]
+    categories = categorize_changes(commits)
+    assert "Features" in categories
+    assert len(categories["Features"]) == 1
+
+def test_generate_changelog_entry():
+    version = "v1.0.0"
+    commits = [
+        MagicMock(message="feat: new feature"),
+        MagicMock(message="fix: bug fix"),
+        MagicMock(message="docs: update docs")
+    ]
+    entry = generate_changelog_entry(version, commits)
+    assert "## [1.0.0]" in entry
+    assert "### Features" in entry
+    assert "### Bug Fixes" in entry
+    assert "### Documentation" in entry
+
+def test_get_repository_info(mock_repo):
+    mock_repo.remotes.origin.url = "https://github.com/user/repo.git"
+    info = get_repository_info()
+    assert info["url"] == "https://github.com/user/repo.git"
+    assert info["name"] == "repo"
+
+def test_generate_release_notes():
+    commits = [
+        MagicMock(message="feat: new feature"),
+        MagicMock(message="fix: bug fix")
+    ]
+    notes = generate_release_notes(commits, {"name": "repo"})
+    assert "New Features" in notes
+    assert "Bug Fixes" in notes
+
+def test_update_changelog(tmp_path):
+    changelog_path = tmp_path / "CHANGELOG.md"
+    changelog_path.write_text("# Changelog\n\n## [Unreleased]\n")
+    
+    version = "v1.0.0"
+    commits = [MagicMock(message="feat: new feature")]
+    
+    update_changelog(version, commits)
+    content = changelog_path.read_text()
+    assert "## [1.0.0]" in content
+    assert "## [Unreleased]" in content
+
+def test_get_unreleased_changes(mock_repo, mock_commit):
+    mock_repo.iter_commits.return_value = [mock_commit]
+    changes = get_unreleased_changes()
+    assert len(changes) == 1
+    assert changes[0].message == "feat: add new feature"
+
+def test_update_unreleased_changelog(tmp_path):
+    changelog_path = tmp_path / "CHANGELOG.md"
+    changelog_path.write_text("# Changelog\n\n## [Unreleased]\n")
+    
+    commits = [MagicMock(message="feat: new feature")]
+    update_unreleased_changelog(commits)
+    
+    content = changelog_path.read_text()
+    assert "### Features" in content
+    assert "new feature" in content
+
+def test_commit_hook(tmp_path):
+    changelog_path = tmp_path / "CHANGELOG.md"
+    changelog_path.write_text("# Changelog\n\n## [Unreleased]\n")
+    
+    with patch('gitwise.features.changelog.get_unreleased_changes') as mock:
+        mock.return_value = [MagicMock(message="feat: new feature")]
+        commit_hook()
+    
+    content = changelog_path.read_text()
+    assert "### Features" in content
+
+def test_setup_commit_hook(tmp_path):
+    git_dir = tmp_path / ".git"
+    hooks_dir = git_dir / "hooks"
+    hooks_dir.mkdir(parents=True)
+    
+    with patch('gitwise.features.changelog.Repo') as mock:
+        mock.return_value.git_dir = str(git_dir)
+        setup_commit_hook()
+    
+    pre_commit = hooks_dir / "pre-commit"
+    assert pre_commit.exists()
+    assert "gitwise changelog --auto-update" in pre_commit.read_text()
+
+def test_changelog_command_with_version(mock_repo):
+    with patch('gitwise.features.changelog.generate_changelog_entry') as mock:
+        mock.return_value = "## [1.0.0]"
+        changelog_command(version="v1.0.0")
+        mock.assert_called_once()
+
+def test_changelog_command_without_version(mock_repo):
+    with patch('gitwise.features.changelog.get_version_tags') as mock:
+        mock.return_value = [MagicMock(name="v1.0.0")]
+        changelog_command()
+        mock.assert_called_once()
+
+def test_changelog_command_with_auto_update(mock_repo):
+    with patch('gitwise.features.changelog.update_unreleased_changelog') as mock:
+        changelog_command(auto_update=True)
+        mock.assert_called_once()
+
+def test_changelog_command_with_setup_hook(mock_repo):
+    with patch('gitwise.features.changelog.setup_commit_hook') as mock:
+        changelog_command(setup_hook=True)
+        mock.assert_called_once() 

--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -1,0 +1,108 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from gitwise.features.commit import (
+    commit_command,
+    group_commits,
+    generate_commit_message,
+    validate_commit_message
+)
+
+@pytest.fixture
+def mock_repo():
+    with patch('gitwise.features.commit.Repo') as mock:
+        repo = MagicMock()
+        mock.return_value = repo
+        yield repo
+
+@pytest.fixture
+def mock_diff():
+    diff = MagicMock()
+    diff.a_path = "test.py"
+    diff.b_path = "test.py"
+    diff.diff = b"@@ -1,1 +1,1 @@\n- old line\n+ new line"
+    return diff
+
+def test_commit_command_with_message(mock_repo):
+    with patch('gitwise.features.commit.validate_commit_message') as mock_validate:
+        mock_validate.return_value = True
+        commit_command(message="feat: add new feature")
+        mock_repo.index.commit.assert_called_once_with("feat: add new feature")
+
+def test_commit_command_with_group(mock_repo, mock_diff):
+    mock_repo.index.diff.return_value = [mock_diff]
+    with patch('gitwise.features.commit.group_commits') as mock_group:
+        mock_group.return_value = {"Features": ["new feature"]}
+        with patch('gitwise.features.commit.generate_commit_message') as mock_gen:
+            mock_gen.return_value = "feat: add new feature"
+            commit_command(group=True)
+            mock_repo.index.commit.assert_called_once_with("feat: add new feature")
+
+def test_group_commits(mock_diff):
+    with patch('gitwise.features.commit.analyze_changes') as mock_analyze:
+        mock_analyze.return_value = {"type": "feat", "description": "new feature"}
+        groups = group_commits([mock_diff])
+        assert "Features" in groups
+        assert "new feature" in groups["Features"]
+
+def test_generate_commit_message():
+    groups = {
+        "Features": ["new feature"],
+        "Bug Fixes": ["fix bug"]
+    }
+    message = generate_commit_message(groups)
+    assert "feat" in message.lower()
+    assert "fix" in message.lower()
+
+def test_validate_commit_message():
+    assert validate_commit_message("feat: add new feature")
+    assert validate_commit_message("fix: resolve bug")
+    assert not validate_commit_message("invalid message")
+    assert not validate_commit_message("feat:")  # Missing description
+
+def test_commit_command_with_invalid_message(mock_repo):
+    with patch('gitwise.features.commit.validate_commit_message') as mock_validate:
+        mock_validate.return_value = False
+        with pytest.raises(ValueError):
+            commit_command(message="invalid message")
+
+def test_commit_command_with_no_changes(mock_repo):
+    mock_repo.index.diff.return_value = []
+    with pytest.raises(ValueError):
+        commit_command(group=True)
+
+def test_group_commits_with_multiple_changes(mock_diff):
+    diff2 = MagicMock()
+    diff2.a_path = "test2.py"
+    diff2.b_path = "test2.py"
+    diff2.diff = b"@@ -1,1 +1,1 @@\n- old line\n+ new line"
+    
+    with patch('gitwise.features.commit.analyze_changes') as mock_analyze:
+        mock_analyze.side_effect = [
+            {"type": "feat", "description": "new feature"},
+            {"type": "fix", "description": "fix bug"}
+        ]
+        groups = group_commits([mock_diff, diff2])
+        assert "Features" in groups
+        assert "Bug Fixes" in groups
+        assert len(groups["Features"]) == 1
+        assert len(groups["Bug Fixes"]) == 1
+
+def test_generate_commit_message_with_breaking_changes():
+    groups = {
+        "Features": ["new feature"],
+        "Breaking Changes": ["remove old API"]
+    }
+    message = generate_commit_message(groups)
+    assert "feat" in message.lower()
+    assert "BREAKING CHANGE" in message
+    assert "remove old API" in message
+
+def test_validate_commit_message_with_scope():
+    assert validate_commit_message("feat(api): add new endpoint")
+    assert validate_commit_message("fix(ui): resolve layout issue")
+    assert not validate_commit_message("feat(): missing scope description")
+
+def test_validate_commit_message_with_breaking_changes():
+    assert validate_commit_message("feat!: remove deprecated API")
+    assert validate_commit_message("feat(api)!: change response format")
+    assert not validate_commit_message("feat! invalid message") 

--- a/tests/test_pr.py
+++ b/tests/test_pr.py
@@ -1,0 +1,112 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from gitwise.features.pr import (
+    pr_command,
+    generate_pr_title,
+    generate_pr_description,
+    validate_branch_name,
+    get_current_branch,
+    get_base_branch
+)
+
+@pytest.fixture
+def mock_repo():
+    with patch('gitwise.features.pr.Repo') as mock:
+        repo = MagicMock()
+        mock.return_value = repo
+        yield repo
+
+@pytest.fixture
+def mock_commit():
+    commit = MagicMock()
+    commit.message = "feat: add new feature"
+    commit.hexsha = "abc123"
+    return commit
+
+def test_pr_command_with_title(mock_repo):
+    with patch('gitwise.features.pr.create_pull_request') as mock_create:
+        mock_create.return_value = {"html_url": "https://github.com/user/repo/pull/1"}
+        pr_command(title="Add new feature")
+        mock_create.assert_called_once()
+
+def test_pr_command_without_title(mock_repo, mock_commit):
+    mock_repo.iter_commits.return_value = [mock_commit]
+    with patch('gitwise.features.pr.generate_pr_title') as mock_gen_title:
+        mock_gen_title.return_value = "Add new feature"
+        with patch('gitwise.features.pr.create_pull_request') as mock_create:
+            mock_create.return_value = {"html_url": "https://github.com/user/repo/pull/1"}
+            pr_command()
+            mock_create.assert_called_once()
+
+def test_generate_pr_title(mock_commit):
+    with patch('gitwise.features.pr.get_commits_since_base') as mock_get:
+        mock_get.return_value = [mock_commit]
+        title = generate_pr_title()
+        assert "Add new feature" in title
+
+def test_generate_pr_description(mock_commit):
+    with patch('gitwise.features.pr.get_commits_since_base') as mock_get:
+        mock_get.return_value = [mock_commit]
+        description = generate_pr_description()
+        assert "## Changes" in description
+        assert "feat: add new feature" in description
+
+def test_validate_branch_name():
+    assert validate_branch_name("feature/new-feature")
+    assert validate_branch_name("fix/bug-fix")
+    assert not validate_branch_name("invalid branch name")
+    assert not validate_branch_name("main")  # Protected branch
+
+def test_get_current_branch(mock_repo):
+    mock_repo.active_branch.name = "feature/new-feature"
+    branch = get_current_branch()
+    assert branch == "feature/new-feature"
+
+def test_get_base_branch(mock_repo):
+    mock_repo.remotes.origin.refs.main.name = "main"
+    base = get_base_branch()
+    assert base == "main"
+
+def test_pr_command_with_invalid_branch(mock_repo):
+    mock_repo.active_branch.name = "main"
+    with pytest.raises(ValueError):
+        pr_command()
+
+def test_pr_command_with_no_commits(mock_repo):
+    mock_repo.iter_commits.return_value = []
+    with pytest.raises(ValueError):
+        pr_command()
+
+def test_generate_pr_title_with_multiple_commits(mock_commit):
+    commit2 = MagicMock()
+    commit2.message = "fix: resolve bug"
+    
+    with patch('gitwise.features.pr.get_commits_since_base') as mock_get:
+        mock_get.return_value = [mock_commit, commit2]
+        title = generate_pr_title()
+        assert "Add new feature" in title
+        assert "resolve bug" in title
+
+def test_generate_pr_description_with_breaking_changes(mock_commit):
+    commit = MagicMock()
+    commit.message = "feat!: remove deprecated API"
+    
+    with patch('gitwise.features.pr.get_commits_since_base') as mock_get:
+        mock_get.return_value = [commit]
+        description = generate_pr_description()
+        assert "## Breaking Changes" in description
+        assert "remove deprecated API" in description
+
+def test_pr_command_with_custom_base(mock_repo, mock_commit):
+    mock_repo.iter_commits.return_value = [mock_commit]
+    with patch('gitwise.features.pr.create_pull_request') as mock_create:
+        mock_create.return_value = {"html_url": "https://github.com/user/repo/pull/1"}
+        pr_command(base="develop")
+        mock_create.assert_called_once()
+
+def test_pr_command_with_draft(mock_repo, mock_commit):
+    mock_repo.iter_commits.return_value = [mock_commit]
+    with patch('gitwise.features.pr.create_pull_request') as mock_create:
+        mock_create.return_value = {"html_url": "https://github.com/user/repo/pull/1"}
+        pr_command(draft=True)
+        mock_create.assert_called_once() 


### PR DESCRIPTION
## Changes
- Add unit tests for PR command and helpers
- Add tests for commit and changelog features
- Enhance changelog generation
  - Add version parsing and comparison
  - Add --create-tag option to changelog command
- Enhance add and commit commands
  - Add smart commit grouping option
  - Simplify add and commit commands
  - Add stage_files and unstage_files functions for selective staging
  - Update analyze_changes to group related file changes
- Enhance PR command 
  - Make labels and checklist opt-in
  - Improve PR command options
  - Add PR enhancement features
  - Refactor to simplify PR creation and remove GitHub CLI integration
- Add prompts for commit messages and PR descriptions
- Refactor LLM usage
  - Add prompts and refactor commit message generation
  - Extract LLM API call to separate function
- Update get_commit_history to compare against remote

## Documentation
- Add API documentation for GitWise
- Add changelog feature documentation 
- Add contributing guidelines
- Add contributor covenant code of conduct
- Enhance README with new feature descriptions and changelog guide
- Update README with new changelog command
- Add MIT license badge and file

## Other
- Add MANIFEST.in for packaging
- Add GitHub Actions workflow for testing and deployment

## Testing
Please test the following:
- Generating commit messages with the new prompts
- Creating PRs with labels and checklists 
- Generating a changelog with version comparisons
- Selectively staging files with the enhanced add command
- Smart grouping of commits based on file changes