### PR TITLE
fix(auth): Improve OpenRouter API key error message (+21 more commits)

### DIFF
--- a/.gitwise/config.json
+++ b/.gitwise/config.json
@@ -1,5 +1,5 @@
 {
   "llm_backend": "online",
-  "openrouter_api_key": "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",
+  "openrouter_api_key": "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",
   "openrouter_model": "mistralai/mixtral-8x7b"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- update OpenRouter API key
 - Add config module for loading and saving GitWise settings
 - add Gitwise configuration file
 - add .internal/ to .gitignore
@@ -34,6 +35,9 @@
 
 ### Other
 
+- load OpenRouter API key from config file or env var
+- streamline push flow by ending after PR creation
+- add config module for loading and saving GitWise settings
 - clarify changelog generation prompt guidance
 - Simplify LLM backend routing logic
 - add config check before pushing changes

--- a/gitwise/llm/online.py
+++ b/gitwise/llm/online.py
@@ -36,5 +36,9 @@ def get_llm_response(prompt_or_messages: Union[str, List[Dict[str, str]]]) -> st
         return response.choices[0].message.content.strip()
     except Exception as e:
         if hasattr(e, 'status_code') and e.status_code == 401:
-            raise RuntimeError("Authentication failed (401). Please set OPENROUTER_API_KEY.") from e
+            raise RuntimeError(
+                "Authentication failed (401). Your OpenRouter API key was found, but was rejected by the server. "
+                "This may mean your key is invalid, disabled, revoked, a provisioning key, or you lack access to the requested model. "
+                "Please check your OpenRouter dashboard or try generating a new key."
+            ) from e
         raise RuntimeError(f"Error getting LLM response: {str(e)}") from e 


### PR DESCRIPTION
### Summary of Changes
This PR introduces major enhancements to GitWise, focusing on configuration management, streamlining workflows, and expanding LLM backend support. It adds a new `config` module for loading and saving GitWise settings, simplifies the push flow, and introduces an interactive `init` command for easy setup. Additionally, it adds support for the Ollama LLM backend and offline mode.

### Key Features
- Added `config` module for loading and saving GitWise settings
  - Load OpenRouter API key from config file or environment variable
  - Update OpenRouter API key via config
- Streamlined push flow by ending after PR creation
- Added config checks before pushing changes, creating PRs, and running commit command
- Introduced `init` command for interactive GitWise setup
- Added support for Ollama LLM backend and offline mode
- Improved error handling and messages for OpenRouter API key issues

### Enhancements
- Simplified LLM backend routing logic
- Improved changelog generation prompt guidance
- Added documentation guidelines to meta-level rules

### Bug Fixes
- Fixed OpenRouter API key error message in auth module

### Testing Done
Manual testing performed for new features and enhancements. Verified config loading, saving, and error handling. Tested streamlined push flow, `init` command, and Ollama backend integration.

### Potential Impact
No breaking changes expected. Users will benefit from the new `init` command for easier setup and the ability to use the Ollama LLM backend or work offline. Existing users may need to update their configuration to take advantage of the new features.