### PR TITLE
Limit Python testing to just 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ jobs:
       matrix:
         python-version: ['3.11']  # Latest stable version for primary testing
         include:
-          - python-version: '3.8'  # Minimum supported version
-            test-type: 'min-version'
           - python-version: '3.11'
             test-type: 'full'
 


### PR DESCRIPTION
# Limit Python testing to 3.11

## Motivation

To simplify the CI pipeline and reduce testing time, we decided to focus on the latest stable Python version.

## Changes

- Updated `.github/workflows/tests.yml` to only test against Python 3.11

## Breaking Changes

None

## Testing

- Ran the updated CI workflow to ensure tests pass with Python 3.11

## Related Issues

- Closes #217