### PR TITLE
Disable coverage upload in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,12 +50,12 @@ jobs:
     #     isort --check-only gitwise tests
     #     mypy gitwise tests || true  # Allow mypy to fail for now
     
-    - name: Upload coverage
-      if: matrix.test-type == 'full'  # Only upload coverage once
-      uses: codecov/codecov-action@v3
-      with:
-        file: ./coverage.xml
-        fail_ci_if_error: true
+    # - name: Upload coverage
+    #   if: matrix.test-type == 'full'  # Only upload coverage once
+    #   uses: codecov/codecov-action@v3
+    #   with:
+    #     file: ./coverage.xml
+    #     fail_ci_if_error: true
 
   test-deploy:
     needs: test


### PR DESCRIPTION
# Disable coverage upload in CI

## Motivation

Coverage upload is causing the CI workflow to fail due to intermittent issues with the coverage service. Disabling it for now to stabilize the CI process.

## Changes

- Remove the `upload-coverage` step from the `.github/workflows/ci.yml` file

## Breaking Changes

None.

## Testing

- Verified that the CI workflow passes successfully without the coverage upload step

## Related Issues

- Fixes #1234