### PR TITLE
Add verbose flag to twine upload commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
       run: |
         python -m build
-        twine upload --repository testpypi dist/*
+        twine upload --repository testpypi dist/* --verbose 
 
   deploy:
     needs: test
@@ -107,4 +107,4 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
       run: |
         python -m build
-        twine upload dist/* 
+        twine upload dist/* --verbose 


### PR DESCRIPTION
## Summary
Add verbose flag to twine upload commands

## Motivation
To provide more visibility into the twine upload process.

## Changes
- Added `--verbose` flag to twine upload commands.

## Breaking Changes
None

## Testing
Tested the verbose flag on multiple packages before and after uploading to PyPI.

## Related Issues
N/A

## Checklist
- [ ] Added comments for clarity
- [ ] All tests pass
- [ ] Changes are backward compatible
- [ ] Checked for duplicate keys
- [ ] Checked for necessary permissions
- [ ] Checked for sensitive data
- [ ] Code follows project style guide
- [ ] Documentation is up to date
- [ ] No sensitive data in changes
- [ ] Performance impact considered
- [ ] Security implications reviewed
- [ ] Updated schema if needed
- [ ] Validated YAML format
- [ ] Verified environment variables
- [ ] Verified indentation
- [ ] Verified workflow triggers